### PR TITLE
Add option to tweet published blog posts

### DIFF
--- a/src/GordonBeemingCom.Editor/Pages/PostUpdate.razor
+++ b/src/GordonBeemingCom.Editor/Pages/PostUpdate.razor
@@ -8,6 +8,7 @@
 @inject IFileService fileService
 @inject IHttpContextAccessor httpContextAccessor
 @inject IExternalUrlsService externalUrlsService
+@inject TwitterService twitterService
 @attribute [Authorize]
 
 <PageTitle>@blogName | Posts</PageTitle>
@@ -75,6 +76,10 @@ else
       <div class="form-group col-lg-4 col-sm-12">
         <InputFile id="heroImage" class="form-control" OnChange="OnHeroImageSelected" />
       </div>
+      <div class="form-group col-lg-12 col-sm-12">
+        <label for="tweetPost">Tweet this post:</label>
+        <InputCheckbox id="tweetPost" @bind-Value="@shouldTweet" />
+      </div>
     </div>
 
     @if (validationIssues.Count > 0)
@@ -139,6 +144,7 @@ else
 
   private bool formSumitting = false;
   private bool fileUploadTooBig = false;
+  private bool shouldTweet = false;
 
   protected override async Task OnInitializedAsync()
   {
@@ -268,6 +274,14 @@ else
           await externalUrlsService.RegisterUrlsAsync(htmlContext.Html);
           await externalUrlsService.CommitChangesAsync();
         }
+      }
+      if (shouldTweet && !string.IsNullOrWhiteSpace(blog.BlogTitle) && blog.PublishDate.HasValue)
+      {
+          var tweetResult = await twitterService.TweetBlogPostAsync($"New blog post: {blog.BlogTitle} {configuration["WebSiteUrl"]}/blog/{blog.BlogSlug}");
+          if (!tweetResult)
+          {
+              Console.WriteLine("Failed to tweet the blog post.");
+          }
       }
       await Task.Delay(1000);
       if (Id == Guid.Empty)

--- a/src/GordonBeemingCom.Editor/Services/TwitterService.cs
+++ b/src/GordonBeemingCom.Editor/Services/TwitterService.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Tweetinvi;
+using Tweetinvi.Parameters;
+
+namespace GordonBeemingCom.Editor.Services
+{
+    public class TwitterService
+    {
+        private readonly IConfiguration _configuration;
+
+        public TwitterService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            InitializeTwitterClient();
+        }
+
+        private void InitializeTwitterClient()
+        {
+            var apiKey = _configuration["TwitterApi:ApiKey"];
+            var apiSecretKey = _configuration["TwitterApi:ApiSecretKey"];
+            var accessToken = _configuration["TwitterApi:AccessToken"];
+            var accessTokenSecret = _configuration["TwitterApi:AccessTokenSecret"];
+
+            var client = new TwitterClient(apiKey, apiSecretKey, accessToken, accessTokenSecret);
+            TweetinviConfig.CurrentThreadSettings.TwitterClient = client;
+        }
+
+        public async Task<bool> TweetBlogPostAsync(string message)
+        {
+            try
+            {
+                var tweet = await TweetinviConfig.CurrentThreadSettings.TwitterClient.Tweets.PublishTweetAsync(new PublishTweetParameters(message));
+                return tweet != null;
+            }
+            catch (Exception ex)
+            {
+                // Log the exception
+                Console.WriteLine($"Failed to tweet message. Exception: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/src/GordonBeemingCom.Editor/appsettings.json
+++ b/src/GordonBeemingCom.Editor/appsettings.json
@@ -9,5 +9,11 @@
   "AllowedHosts": "*",
   "Blog": {
     "Username": "gordon@beeming.net"
+  },
+  "TwitterApi": {
+    "ApiKey": "YOUR_API_KEY",
+    "ApiSecretKey": "YOUR_API_SECRET_KEY",
+    "AccessToken": "YOUR_ACCESS_TOKEN",
+    "AccessTokenSecret": "YOUR_ACCESS_TOKEN_SECRET"
   }
 }


### PR DESCRIPTION
Related to #241

This pull request introduces the functionality to tweet a blog post upon publishing, providing the user with the option to do so through a new checkbox in the blog post update form.

- **Adds a checkbox** in `src/GordonBeemingCom.Editor/Pages/PostUpdate.razor` for users to select if they want to tweet the blog post upon publishing.
- **Implements Twitter integration** by adding Twitter API configuration settings (`ApiKey`, `ApiSecretKey`, `AccessToken`, and `AccessTokenSecret`) in `src/GordonBeemingCom.Editor/appsettings.json`.
- **Creates a new service**, `TwitterService`, in `src/GordonBeemingCom.Editor/Services/TwitterService.cs` to handle Twitter API calls. This service includes a method to post tweets, which is called based on the state of the newly added "Tweet this post" checkbox.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GordonBeeming/GordonBeemingCom/issues/241?shareId=e8441d50-db3f-4777-964f-f6af13633daa).