### PR TITLE
Add option to tweet published blog posts

### DIFF
--- a/src/GordonBeemingCom.Editor/Pages/PostUpdate.razor
+++ b/src/GordonBeemingCom.Editor/Pages/PostUpdate.razor
@@ -8,6 +8,7 @@
 @inject IFileService fileService
 @inject IHttpContextAccessor httpContextAccessor
 @inject IExternalUrlsService externalUrlsService
+@inject TwitterService twitterService
 @attribute [Authorize]
 
 <PageTitle>@blogName | Posts</PageTitle>
@@ -75,6 +76,10 @@ else
       <div class="form-group col-lg-4 col-sm-12">
         <InputFile id="heroImage" class="form-control" OnChange="OnHeroImageSelected" />
       </div>
+      <div class="form-group col-lg-12 col-sm-12">
+        <label for="tweetPost">Tweet this post:</label>
+        <InputCheckbox id="tweetPost" @bind-Value="@shouldTweet" />
+      </div>
     </div>
 
     @if (validationIssues.Count > 0)
@@ -139,6 +144,7 @@ else
 
   private bool formSumitting = false;
   private bool fileUploadTooBig = false;
+  private bool shouldTweet = false;
 
   protected override async Task OnInitializedAsync()
   {
@@ -267,6 +273,14 @@ else
           }
           await externalUrlsService.RegisterUrlsAsync(htmlContext.Html);
           await externalUrlsService.CommitChangesAsync();
+        }
+      }
+      if (shouldTweet && !string.IsNullOrWhiteSpace(blog.BlogSlug))
+      {
+        var tweetResult = await twitterService.TweetBlogPostAsync($"New blog post: {blog.BlogTitle}", $"{configuration["WebSiteUrl"]}/blog/{blog.BlogSlug}");
+        if (!tweetResult)
+        {
+            Console.WriteLine("Failed to tweet the blog post.");
         }
       }
       await Task.Delay(1000);

--- a/src/GordonBeemingCom.Editor/Services/TwitterService.cs
+++ b/src/GordonBeemingCom.Editor/Services/TwitterService.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using Tweetinvi;
+using Tweetinvi.Parameters;
+
+namespace GordonBeemingCom.Editor.Services
+{
+    public class TwitterService
+    {
+        private readonly IConfiguration _configuration;
+
+        public TwitterService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            InitializeClient();
+        }
+
+        private void InitializeClient()
+        {
+            var consumerKey = _configuration["TwitterAPI:ApiKey"];
+            var consumerSecret = _configuration["TwitterAPI:ApiSecretKey"];
+            var accessToken = _configuration["TwitterAPI:AccessToken"];
+            var accessTokenSecret = _configuration["TwitterAPI:AccessTokenSecret"];
+
+            var userClient = new TwitterClient(consumerKey, consumerSecret, accessToken, accessTokenSecret);
+            TweetinviConfig.CurrentThreadSettings.TwitterClient = userClient;
+        }
+
+        public async Task<bool> TweetBlogPostAsync(string message, string url)
+        {
+            var tweet = await TweetinviConfig.CurrentThreadSettings.TwitterClient.Tweets.PublishTweetAsync(new PublishTweetParameters($"{message} {url}"));
+            return tweet != null;
+        }
+    }
+}

--- a/src/GordonBeemingCom.Editor/appsettings.json
+++ b/src/GordonBeemingCom.Editor/appsettings.json
@@ -9,5 +9,11 @@
   "AllowedHosts": "*",
   "Blog": {
     "Username": "gordon@beeming.net"
+  },
+  "TwitterAPI": {
+    "ApiKey": "YOUR_API_KEY",
+    "ApiSecretKey": "YOUR_API_SECRET_KEY",
+    "AccessToken": "YOUR_ACCESS_TOKEN",
+    "AccessTokenSecret": "YOUR_ACCESS_TOKEN_SECRET"
   }
 }


### PR DESCRIPTION
Related to #241

This pull request introduces functionality to allow users to choose whether a blog post should be tweeted upon publication, along with the necessary backend support for Twitter integration.

- **UI Update**: Adds a "Tweet this post" checkbox in the `PostUpdate.razor` page, enabling users to select if the blog post should be tweeted.
- **Twitter Service**: Implements a new `TwitterService` class in `Services`, which handles Twitter API calls using credentials stored in `appsettings.json`.
- **Configuration**: Updates `appsettings.json` to include Twitter API credentials, allowing the application to authenticate and interact with the Twitter API.
- **Tweet Logic**: Integrates tweet functionality into the blog post update workflow. If the "Tweet this post" checkbox is selected, the blog post title and URL are tweeted using the newly added `TwitterService`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GordonBeeming/GordonBeemingCom/issues/241?shareId=24def822-c5cd-459d-9e95-a69d401b8f7c).