### PR TITLE
fix(docker): update .NET SDK and ASP.NET base images

### DIFF
--- a/src/GordonBeemingCom.Editor/Dockerfile
+++ b/src/GordonBeemingCom.Editor/Dockerfile
@@ -11,7 +11,7 @@ ENV BRANCH_NAME=$A_BRANCH_NAME
 RUN apk add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY ["global.json", "GordonBeemingCom.Editor/global.json"]
 COPY ["Directory.*.props", "./"]

--- a/src/GordonBeemingCom/Dockerfile
+++ b/src/GordonBeemingCom/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-preview-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
@@ -11,7 +11,7 @@ ENV BRANCH_NAME=$A_BRANCH_NAME
 RUN apk add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-preview-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY ["global.json", "GordonBeemingCom/global.json"]
 COPY ["Directory.*.props", "./"]


### PR DESCRIPTION
Replace preview Alpine images with stable .NET 9.0 images in the 
Dockerfiles for both the editor and main application. This change 
ensures a more stable and reliable build environment by using the 
latest stable release, improving compatibility and reducing the 
risk of issues related to preview versions.