### PR TITLE
refactor(docker): switch to Alpine images for efficiency

### DIFF
--- a/src/GordonBeemingCom.Editor/Dockerfile
+++ b/src/GordonBeemingCom.Editor/Dockerfile
@@ -11,7 +11,7 @@ ENV BRANCH_NAME=$A_BRANCH_NAME
 RUN apk add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 WORKDIR /src
 COPY ["global.json", "GordonBeemingCom.Editor/global.json"]
 COPY ["Directory.*.props", "./"]

--- a/src/GordonBeemingCom/Dockerfile
+++ b/src/GordonBeemingCom/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS base
 WORKDIR /app
 EXPOSE 80
 ENV ASPNETCORE_URLS=http://+:80
@@ -11,7 +11,7 @@ ENV BRANCH_NAME=$A_BRANCH_NAME
 RUN apk add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 WORKDIR /src
 COPY ["global.json", "GordonBeemingCom/global.json"]
 COPY ["Directory.*.props", "./"]


### PR DESCRIPTION
Replace the base and build images in Dockerfiles their 
Alpine counterparts to reduce image size and improve 
performance. This change enhances the overall efficiency 
of the containerized applications.